### PR TITLE
#15 - Safely getters added

### DIFF
--- a/config.go
+++ b/config.go
@@ -86,15 +86,23 @@ func (p *Config) GetNode(path string) *hocon.HoconValue {
 	return currentNode
 }
 
-func (p *Config) GetBoolean(path string, defaultVal ...bool) bool {
+func (p *Config) GetBooleanSafely(path string, defaultVal ...bool) (bool, error) {
 	obj := p.GetNode(path)
 	if obj == nil {
 		if len(defaultVal) > 0 {
-			return defaultVal[0]
+			return defaultVal[0], nil
 		}
-		return false
+		return false, nil
 	}
-	return obj.GetBoolean()
+	return obj.GetBooleanSafely()
+}
+
+func (p *Config) GetBoolean(path string, defaultVal ...bool) bool {
+	val, err := p.GetBooleanSafely(path, defaultVal...)
+	if err != nil {
+		panic(err)
+	}
+	return val
 }
 
 func (p *Config) GetByteSize(path string) *big.Int {
@@ -105,26 +113,42 @@ func (p *Config) GetByteSize(path string) *big.Int {
 	return obj.GetByteSize()
 }
 
-func (p *Config) GetInt32(path string, defaultVal ...int32) int32 {
+func (p *Config) GetInt32Safely(path string, defaultVal ...int32) (int32, error) {
 	obj := p.GetNode(path)
 	if obj == nil {
 		if len(defaultVal) > 0 {
-			return defaultVal[0]
+			return defaultVal[0], nil
 		}
-		return 0
+		return 0, nil
 	}
-	return obj.GetInt32()
+	return obj.GetInt32Safely()
+}
+
+func (p *Config) GetInt32(path string, defaultVal ...int32) int32 {
+	val, err := p.GetInt32Safely(path, defaultVal...)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *Config) GetInt64Safely(path string, defaultVal ...int64) (int64, error) {
+	obj := p.GetNode(path)
+	if obj == nil {
+		if len(defaultVal) > 0 {
+			return defaultVal[0], nil
+		}
+		return 0, nil
+	}
+	return obj.GetInt64Safely()
 }
 
 func (p *Config) GetInt64(path string, defaultVal ...int64) int64 {
-	obj := p.GetNode(path)
-	if obj == nil {
-		if len(defaultVal) > 0 {
-			return defaultVal[0]
-		}
-		return 0
+	val, err := p.GetInt64Safely(path, defaultVal...)
+	if err != nil {
+		panic(err)
 	}
-	return obj.GetInt64()
+	return val
 }
 
 func (p *Config) GetString(path string, defaultVal ...string) string {
@@ -138,25 +162,42 @@ func (p *Config) GetString(path string, defaultVal ...string) string {
 	return obj.GetString()
 }
 
-func (p *Config) GetFloat32(path string, defaultVal ...float32) float32 {
+func (p *Config) GetFloat32Safely(path string, defaultVal ...float32) (float32, error) {
 	obj := p.GetNode(path)
 	if obj == nil {
 		if len(defaultVal) > 0 {
-			return defaultVal[0]
+			return defaultVal[0], nil
 		}
+		return 0, nil
 	}
-	return obj.GetFloat32()
+	return obj.GetFloat32Safely()
+}
+
+func (p *Config) GetFloat32(path string, defaultVal ...float32) float32 {
+	val, err := p.GetFloat32Safely(path, defaultVal...)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *Config) GetFloat64Safely(path string, defaultVal ...float64) (float64, error) {
+	obj := p.GetNode(path)
+	if obj == nil {
+		if len(defaultVal) > 0 {
+			return defaultVal[0], nil
+		}
+		return 0, nil
+	}
+	return obj.GetFloat64Safely()
 }
 
 func (p *Config) GetFloat64(path string, defaultVal ...float64) float64 {
-	obj := p.GetNode(path)
-	if obj == nil {
-		if len(defaultVal) > 0 {
-			return defaultVal[0]
-		}
-		return 0
+	val, err := p.GetFloat64Safely(path, defaultVal...)
+	if err != nil {
+		panic(err)
 	}
-	return obj.GetFloat64()
+	return val
 }
 
 func (p *Config) GetTimeDuration(path string, defaultVal ...time.Duration) time.Duration {
@@ -181,52 +222,100 @@ func (p *Config) GetTimeDurationInfiniteNotAllowed(path string, defaultVal ...ti
 	return obj.GetTimeDuration(false)
 }
 
-func (p *Config) GetBooleanList(path string) []bool {
+func (p *Config) GetBooleanListSafely(path string) ([]bool, error) {
 	obj := p.GetNode(path)
 	if obj == nil {
-		return nil
+		return nil, nil
 	}
-	return obj.GetBooleanList()
+	return obj.GetBooleanListSafely()
+}
+
+func (p *Config) GetBooleanList(path string) []bool {
+	val, err := p.GetBooleanListSafely(path)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *Config) GetFloat32ListSafely(path string) ([]float32, error) {
+	obj := p.GetNode(path)
+	if obj == nil {
+		return nil, nil
+	}
+	return obj.GetFloat32ListSafely()
 }
 
 func (p *Config) GetFloat32List(path string) []float32 {
+	val, err := p.GetFloat32ListSafely(path)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *Config) GetFloat64ListSafely(path string) ([]float64, error) {
 	obj := p.GetNode(path)
 	if obj == nil {
-		return nil
+		return nil, nil
 	}
-	return obj.GetFloat32List()
+	return obj.GetFloat64ListSafely()
 }
 
 func (p *Config) GetFloat64List(path string) []float64 {
+	val, err := p.GetFloat64ListSafely(path)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *Config) GetInt32ListSafely(path string) ([]int32, error) {
 	obj := p.GetNode(path)
 	if obj == nil {
-		return nil
+		return nil, nil
 	}
-	return obj.GetFloat64List()
+	return obj.GetInt32ListSafely()
 }
 
 func (p *Config) GetInt32List(path string) []int32 {
+	val, err := p.GetInt32ListSafely(path)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *Config) GetInt64ListSafely(path string) ([]int64, error) {
 	obj := p.GetNode(path)
 	if obj == nil {
-		return nil
+		return nil, nil
 	}
-	return obj.GetInt32List()
+	return obj.GetInt64ListSafely()
 }
 
 func (p *Config) GetInt64List(path string) []int64 {
+	val, err := p.GetInt64ListSafely(path)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *Config) GetByteListSafely(path string) ([]byte, error) {
 	obj := p.GetNode(path)
 	if obj == nil {
-		return nil
+		return nil, nil
 	}
-	return obj.GetInt64List()
+	return obj.GetByteListSafely()
 }
 
 func (p *Config) GetByteList(path string) []byte {
-	obj := p.GetNode(path)
-	if obj == nil {
-		return nil
+	val, err := p.GetByteListSafely(path)
+	if err != nil {
+		panic(err)
 	}
-	return obj.GetByteList()
+	return val
 }
 
 func (p *Config) GetStringList(path string) []string {

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -2,6 +2,7 @@ package configuration
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"runtime"
 	"sync"
 	"testing"
@@ -42,4 +43,187 @@ func TestParseKeyOrder(t *testing.T) {
 	go fn()
 
 	wg.Wait()
+}
+
+func TestConfig_GetBoolean(t *testing.T) {
+	conf := ParseString("{k1:TRUE, k2:faLSE, k3: yes,k4:no, k5 : on , k6:oFf}")
+	assert.Equal(t, true, conf.GetBoolean("k1"))
+	assert.Equal(t, false, conf.GetBoolean("k2"))
+	assert.Equal(t, true, conf.GetBoolean("k3"))
+	assert.Equal(t, false, conf.GetBoolean("k4"))
+	assert.Equal(t, true, conf.GetBoolean("k5"))
+	assert.Equal(t, false, conf.GetBoolean("k6"))
+}
+
+func TestConfig_GetInt32(t *testing.T) {
+	conf := ParseString("{k1:2147483647, k2:-2147483648,}")
+	assert.Equal(t, int32(2147483647), conf.GetInt32("k1"))
+	assert.Equal(t, int32(-2147483648), conf.GetInt32("k2"))
+}
+
+func TestConfig_GetInt64(t *testing.T) {
+	conf := ParseString("{k1:9223372036854775807, k2:-9223372036854775808,}")
+	assert.Equal(t, int64(9223372036854775807), conf.GetInt64("k1"))
+	assert.Equal(t, int64(-9223372036854775808), conf.GetInt64("k2"))
+}
+
+func TestConfig_GetFloat32(t *testing.T) {
+	conf := ParseString("{k1:1e3, k2:1e-3,}")
+	assert.Equal(t, float32(1000), conf.GetFloat32("k1"))
+	assert.Equal(t, float32(0.001), conf.GetFloat32("k2"))
+}
+
+func TestConfig_GetFloat64(t *testing.T) {
+	conf := ParseString("{k1:1e3, k2:1e-3,}")
+	assert.Equal(t, 1000., conf.GetFloat64("k1"))
+	assert.Equal(t, 0.001, conf.GetFloat64("k2"))
+}
+
+func TestConfig_GetBooleanSafely(t *testing.T) {
+	conf := ParseString("{k1:TRUE, k2:faLSE, k3: yes,k4:no, k5 : on , k6:oFf}")
+	var v bool
+	var err error
+
+	v, err = conf.GetBooleanSafely("k1")
+	if assert.Nil(t, err) {
+		assert.Equal(t, true, v)
+	}
+
+	v, err = conf.GetBooleanSafely("k2")
+	if assert.Nil(t, err) {
+		assert.Equal(t, false, v)
+	}
+
+	v, err = conf.GetBooleanSafely("k3")
+	if assert.Nil(t, err) {
+		assert.Equal(t, true, v)
+	}
+
+	v, err = conf.GetBooleanSafely("k4")
+	if assert.Nil(t, err) {
+		assert.Equal(t, false, v)
+	}
+
+	v, err = conf.GetBooleanSafely("k5")
+	if assert.Nil(t, err) {
+		assert.Equal(t, true, v)
+	}
+
+	v, err = conf.GetBooleanSafely("k6")
+	if assert.Nil(t, err) {
+		assert.Equal(t, false, v)
+	}
+}
+
+func TestConfig_GetBooleanSafelyError(t *testing.T) {
+	conf := ParseString("{k1:qwerty,}")
+
+	_, err := conf.GetBooleanSafely("k1")
+	assert.Error(t, err)
+}
+
+func TestConfig_GetInt32Safely(t *testing.T) {
+	conf := ParseString("{k1:2147483647, k2:-2147483648,}")
+	var v int32
+	var err error
+
+	v, err = conf.GetInt32Safely("k1")
+	if assert.Nil(t, err) {
+		assert.Equal(t, int32(2147483647), v)
+	}
+
+	v, err = conf.GetInt32Safely("k2")
+	if assert.Nil(t, err) {
+		assert.Equal(t, int32(-2147483648), v)
+	}
+}
+
+func TestConfig_GetInt32SafelyError(t *testing.T) {
+	conf := ParseString("{k1:2147483648, k2:-2147483649, k3: qwerty}")
+	var err error
+
+	_, err = conf.GetInt32Safely("k1")
+	assert.Error(t, err)
+
+	_, err = conf.GetInt32Safely("k2")
+	assert.Error(t, err)
+
+	_, err = conf.GetInt32Safely("k3")
+	assert.Error(t, err)
+}
+
+func TestConfig_GetInt64Safely(t *testing.T) {
+	conf := ParseString("{k1:9223372036854775807, k2:-9223372036854775808,}")
+	var v int64
+	var err error
+
+	v, err = conf.GetInt64Safely("k1")
+	if assert.Nil(t, err) {
+		assert.Equal(t, int64(9223372036854775807), v)
+	}
+
+	v, err = conf.GetInt64Safely("k2")
+	if assert.Nil(t, err) {
+		assert.Equal(t, int64(-9223372036854775808), v)
+	}
+}
+
+func TestConfig_GetInt64SafelyError(t *testing.T) {
+	conf := ParseString("{k1:9223372036854775808, k2:-9223372036854775809, k3: qwerty}")
+	var err error
+
+	_, err = conf.GetInt64Safely("k1")
+	assert.Error(t, err)
+
+	_, err = conf.GetInt64Safely("k2")
+	assert.Error(t, err)
+
+	_, err = conf.GetInt64Safely("k3")
+	assert.Error(t, err)
+}
+
+func TestConfig_GetFloat32Safely(t *testing.T) {
+	conf := ParseString("{k1:1e3, k2:1e-3,}")
+	var v float32
+	var err error
+
+	v, err = conf.GetFloat32Safely("k1")
+	if assert.Nil(t, err) {
+		assert.Equal(t, float32(1000), v)
+	}
+
+	v, err = conf.GetFloat32Safely("k2")
+	if assert.Nil(t, err) {
+		assert.Equal(t, float32(0.001), v)
+	}
+}
+
+func TestConfig_GetFloat32SafelyError(t *testing.T) {
+	conf := ParseString("{k1:qwerty,}")
+
+	_, err := conf.GetFloat32Safely("k1")
+	assert.Error(t, err)
+}
+
+func TestConfig_GetFloat64Safely(t *testing.T) {
+	conf := ParseString("{k1:1e3, k2:1e-3,}")
+	var v float64
+	var err error
+
+	v, err = conf.GetFloat64Safely("k1")
+	if assert.Nil(t, err) {
+		assert.Equal(t, 1000., v)
+	}
+
+	v, err = conf.GetFloat64Safely("k2")
+	if assert.Nil(t, err) {
+		assert.Equal(t, 0.001, v)
+	}
+}
+
+func TestConfig_GetFloat64SafelyError(t *testing.T) {
+	conf := ParseString("{k1:qwerty,}")
+
+	_, err := conf.GetFloat64Safely("k1")
+	assert.Error(t, err)
 }

--- a/hocon/value.go
+++ b/hocon/value.go
@@ -242,16 +242,24 @@ func (p *HoconValue) NewValue(value HoconElement) {
 	p.values = append(p.values, value)
 }
 
-func (p *HoconValue) GetBoolean() bool {
-	v := strings.ToLower(p.GetString())
-	switch v {
+func (p *HoconValue) GetBooleanSafely() (bool, error) {
+	v := p.GetString()
+	switch strings.ToLower(v) {
 	case "on", "true", "yes":
-		return true
+		return true, nil
 	case "off", "false", "no":
-		return false
+		return false, nil
 	default:
-		panic("Unknown boolean format: " + v)
+		return false, fmt.Errorf("unknown boolean format: %s", v)
 	}
+}
+
+func (p *HoconValue) GetBoolean() bool {
+	v, err := p.GetBooleanSafely()
+	if err != nil {
+		panic(err)
+	}
+	return v
 }
 
 func (p *HoconValue) GetString() string {
@@ -261,98 +269,193 @@ func (p *HoconValue) GetString() string {
 	return ""
 }
 
+func (p *HoconValue) GetFloat64Safely() (float64, error) {
+	return strconv.ParseFloat(p.GetString(), 64)
+}
+
 func (p *HoconValue) GetFloat64() float64 {
-	val, err := strconv.ParseFloat(p.GetString(), 64)
+	val, err := p.GetFloat64Safely()
 	if err != nil {
 		panic(err)
 	}
 	return val
+}
+
+func (p *HoconValue) GetFloat32Safely() (float32, error) {
+	float, err := strconv.ParseFloat(p.GetString(), 32)
+	return float32(float), err
 }
 
 func (p *HoconValue) GetFloat32() float32 {
-	val, err := strconv.ParseFloat(p.GetString(), 32)
-	if err != nil {
-		panic(err)
-	}
-	return float32(val)
-}
-
-func (p *HoconValue) GetInt64() int64 {
-	val, err := strconv.ParseInt(p.GetString(), 10, 64)
+	val, err := p.GetFloat32Safely()
 	if err != nil {
 		panic(err)
 	}
 	return val
 }
 
-func (p *HoconValue) GetInt32() int32 {
+func (p *HoconValue) GetInt64Safely() (int64, error) {
+	return strconv.ParseInt(p.GetString(), 10, 64)
+}
+
+func (p *HoconValue) GetInt64() int64 {
+	val, err := p.GetInt64Safely()
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *HoconValue) GetInt32Safely() (int32, error) {
 	val, err := strconv.ParseInt(p.GetString(), 10, 32)
+	return int32(val), err
+}
+
+func (p *HoconValue) GetInt32() int32 {
+	val, err := p.GetInt32Safely()
 	if err != nil {
 		panic(err)
 	}
 	return int32(val)
 }
 
-func (p *HoconValue) GetByte() byte {
+func (p *HoconValue) GetByteSafely() (byte, error) {
 	val, err := strconv.ParseUint(p.GetString(), 10, 8)
+	return byte(val), err
+}
+
+func (p *HoconValue) GetByte() byte {
+	val, err := p.GetByteSafely()
 	if err != nil {
 		panic(err)
 	}
-	return byte(val)
+	return val
 }
 
-func (p *HoconValue) GetByteList() []byte {
+func (p *HoconValue) GetByteListSafely() ([]byte, error) {
 	arrs := p.GetArray()
 	var items []byte
 	for _, v := range arrs {
-		items = append(items, v.GetByte())
+		val, err := v.GetByteSafely()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, val)
 	}
-	return items
+	return items, nil
 }
 
-func (p *HoconValue) GetInt32List() []int32 {
+func (p *HoconValue) GetByteList() []byte {
+	val, err := p.GetByteListSafely()
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *HoconValue) GetInt32ListSafely() ([]int32, error) {
 	arrs := p.GetArray()
 	var items []int32
 	for _, v := range arrs {
-		items = append(items, v.GetInt32())
+		val, err := v.GetInt32Safely()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, val)
 	}
-	return items
+	return items, nil
 }
 
-func (p *HoconValue) GetInt64List() []int64 {
+func (p *HoconValue) GetInt32List() []int32 {
+	val, err := p.GetInt32ListSafely()
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *HoconValue) GetInt64ListSafely() ([]int64, error) {
 	arrs := p.GetArray()
 	var items []int64
 	for _, v := range arrs {
-		items = append(items, v.GetInt64())
+		val, err := v.GetInt64Safely()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, val)
 	}
-	return items
+	return items, nil
 }
 
-func (p *HoconValue) GetBooleanList() []bool {
+func (p *HoconValue) GetInt64List() []int64 {
+	val, err := p.GetInt64ListSafely()
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *HoconValue) GetBooleanListSafely() ([]bool, error) {
 	arrs := p.GetArray()
 	var items []bool
 	for _, v := range arrs {
-		items = append(items, v.GetBoolean())
+		val, err := v.GetBooleanSafely()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, val)
 	}
-	return items
+	return items, nil
 }
 
-func (p *HoconValue) GetFloat32List() []float32 {
+func (p *HoconValue) GetBooleanList() []bool {
+	val, err := p.GetBooleanListSafely()
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *HoconValue) GetFloat32ListSafely() ([]float32, error) {
 	arrs := p.GetArray()
 	var items []float32
 	for _, v := range arrs {
-		items = append(items, v.GetFloat32())
+		val, err := v.GetFloat32Safely()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, val)
 	}
-	return items
+	return items, nil
 }
 
-func (p *HoconValue) GetFloat64List() []float64 {
+func (p *HoconValue) GetFloat32List() []float32 {
+	val, err := p.GetFloat32ListSafely()
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func (p *HoconValue) GetFloat64ListSafely() ([]float64, error) {
 	arrs := p.GetArray()
 	var items []float64
 	for _, v := range arrs {
-		items = append(items, v.GetFloat64())
+		val, err := v.GetFloat64Safely()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, val)
 	}
-	return items
+	return items, nil
+}
+
+func (p *HoconValue) GetFloat64List() []float64 {
+	val, err := p.GetFloat64ListSafely()
+	if err != nil {
+		panic(err)
+	}
+	return val
 }
 
 func (p *HoconValue) GetStringList() []string {


### PR DESCRIPTION
The following functions added due to avoid panic in programs. Old functions are still working for backward compatibility, they call these new functions and panic if new functions return error.
```go
func (p *Config) GetBooleanSafely(path string, defaultVal ...bool) (bool, error) {
func (p *Config) GetInt32Safely(path string, defaultVal ...int32) (int32, error) {
func (p *Config) GetInt64Safely(path string, defaultVal ...int64) (int64, error) {
func (p *Config) GetFloat32Safely(path string, defaultVal ...float32) (float32, error) {
func (p *Config) GetFloat64Safely(path string, defaultVal ...float64) (float64, error) {
func (p *Config) GetBooleanListSafely(path string) ([]bool, error) {
func (p *Config) GetFloat32ListSafely(path string) ([]float32, error) {
func (p *Config) GetFloat64ListSafely(path string) ([]float64, error) {
func (p *Config) GetInt32ListSafely(path string) ([]int32, error) {
func (p *Config) GetInt64ListSafely(path string) ([]int64, error) {
func (p *Config) GetByteListSafely(path string) ([]byte, error) {
```

Also added a few tests.